### PR TITLE
Nao retornar campos de documento na listagem

### DIFF
--- a/src/modules/addresses/infra/typeorm/entities/Address.ts
+++ b/src/modules/addresses/infra/typeorm/entities/Address.ts
@@ -27,7 +27,7 @@ class Address {
   @Column()
   state: string;
 
-  @OneToOne(() => User)
+  @OneToOne(() => User, user => user.address)
   @JoinColumn({ name: 'user_id' })
   user: User;
 

--- a/src/modules/addresses/repositories/fakes/FakeAddressesRepository.ts
+++ b/src/modules/addresses/repositories/fakes/FakeAddressesRepository.ts
@@ -1,0 +1,33 @@
+import { v4 as uuidV4 } from 'uuid';
+
+import ICreateAddressDTO from '@modules/addresses/dtos/ICreateAddressDTO';
+import IAddressesRepository from '../IAddressesRepository';
+
+import Address from '../../infra/typeorm/entities/Address';
+
+class FakeAddressesRepository implements IAddressesRepository {
+  addresses: Address[] = [];
+
+  public async create({
+    zip_code,
+    neighborhood,
+    city,
+    state,
+  }: ICreateAddressDTO): Promise<Address> {
+    const address = new Address();
+
+    Object.assign(address, {
+      id: uuidV4(),
+      zip_code,
+      neighborhood,
+      city,
+      state,
+    });
+
+    this.addresses.push(address);
+
+    return address;
+  }
+}
+
+export default FakeAddressesRepository;

--- a/src/modules/users/dtos/ICreateUserDTO.ts
+++ b/src/modules/users/dtos/ICreateUserDTO.ts
@@ -2,7 +2,9 @@ export default interface ICreateUserDTO {
   name: string;
   nickname: string;
   email: string;
+  phone?: string;
   password: string;
+  cnpj?: string;
   document: string;
   is_legal: boolean;
 }

--- a/src/modules/users/infra/http/controllers/UsersController.ts
+++ b/src/modules/users/infra/http/controllers/UsersController.ts
@@ -47,11 +47,27 @@ export default class UsersController {
   public async index(request: Request, response: Response): Promise<Response> {
     const user_id = request.user.id;
 
-    const users = container.resolve(ListUsersService);
+    const {
+      user,
+      address,
+      offset,
+      limit,
+    } = request.query;
 
-    const allUsers = await users.execute();
 
-    return response.json(classToClass(allUsers));
+    const listUser = container.resolve(ListUsersService);
+
+    const users = await listUser.execute({
+      filters: {
+        user: user as string,
+        address: address as string,
+      },
+      offset: Number(offset),
+      limit: Number(limit),
+      user_id,
+    });
+
+    return response.json(classToClass(users));
   }
 
   public async show(request: Request, response: Response): Promise<Response> {

--- a/src/modules/users/infra/http/routes/users.routes.ts
+++ b/src/modules/users/infra/http/routes/users.routes.ts
@@ -32,7 +32,18 @@ usersRouter.post(
   usersController.import,
 );
 
-usersRouter.get('/users', ensureAuthenticated, usersController.index);
+usersRouter.get('/users',
+  celebrate({
+    [Segments.QUERY]: {
+      user: Joi.string().empty(''),
+      address: Joi.string().empty(''),
+      offset: Joi.number().empty(''),
+      limit: Joi.number().empty(''),
+    },
+  }),
+  ensureAuthenticated,
+  usersController.index,
+);
 
 usersRouter.get(
   '/user/:id',

--- a/src/modules/users/infra/typeorm/entities/User.ts
+++ b/src/modules/users/infra/typeorm/entities/User.ts
@@ -4,14 +4,15 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToOne,
 } from 'typeorm';
 
 import { Exclude } from 'class-transformer';
+import Address from '@modules/addresses/infra/typeorm/entities/Address';
 
 @Entity('users')
 class User {
   @PrimaryGeneratedColumn('uuid')
-  @Exclude()
   id: string;
 
   @Column()
@@ -40,6 +41,9 @@ class User {
   is_legal: boolean;
 
   confirm_import: boolean;
+
+  @OneToOne(() => Address, address => address.user)
+  address: Address;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/modules/users/repositories/IUsersRepository.ts
+++ b/src/modules/users/repositories/IUsersRepository.ts
@@ -41,5 +41,15 @@ export default interface IUsersRepository {
   findByDocument(document: string): Promise<User | undefined>;
   findById(id: string): Promise<User | undefined>;
   findByEmail(email: string): Promise<User | undefined>;
-  findAll(): Promise<User[]>;
+  findAll(
+    offset?: number,
+    limit?: number,
+    filters?: {
+      user?: string;
+      address?: string;
+    },
+  ): Promise<[User[], number, boolean, boolean]>
+  showUser(
+    user_id: string,
+  ): Promise<User | undefined>;
 }

--- a/src/modules/users/repositories/fakes/FakeUsersRepository.ts
+++ b/src/modules/users/repositories/fakes/FakeUsersRepository.ts
@@ -131,10 +131,58 @@ class FakeUsersRepository implements IUsersRepository {
     return findUser;
   }
 
-  public async findAll(): Promise<User[]> {
-    return this.users;
+  public async findAll(
+    offset?: number,
+    limit?: number,
+    filters?: {
+      user?: string;
+      address?: string;
+    },
+  ): Promise<[User[], number, boolean, boolean]> {
+    const findUsers = this.users.filter(user => {
+      if (
+        (filters?.user && user.name === filters?.user) ||
+        (filters?.address &&
+          user.address.city === filters?.address) ||
+        (offset && offset === offset) ||
+        (limit && limit === limit)
+      ) {
+        return user;
+      }
+
+      return null;
+    });
+
+    const totalUsers = findUsers.length;
+
+    let previous = true;
+
+    let next = true;
+
+    if (offset === 0) {
+      previous = false;
+    }
+
+    if (limit && offset) {
+      const existNextPage = limit + offset;
+
+      if (existNextPage >= totalUsers) {
+        next = false;
+      }
+    }
+
+    return [findUsers, totalUsers, previous, next];
   }
 
+  public async showUser(
+    user_id: string,
+  ): Promise<User | undefined> {
+    const showUser = this.users.find(
+      user => user.id === user_id,
+    );
+
+    return showUser;
+  }
 }
 
 export default FakeUsersRepository;

--- a/src/modules/users/services/ListUsersService.spec.ts
+++ b/src/modules/users/services/ListUsersService.spec.ts
@@ -1,18 +1,21 @@
+import FakeAddressesRepository from '@modules/addresses/repositories/fakes/FakeAddressesRepository';
 import FakeUsersRepository from '../repositories/fakes/FakeUsersRepository';
 import ListUsersService from './ListUsersService';
 
 let fakeUsersRepository: FakeUsersRepository;
+let fakeAddressesRepository: FakeAddressesRepository;
 let listUsers: ListUsersService;
 
 describe('ListUser', () => {
   beforeEach(() => {
     fakeUsersRepository = new FakeUsersRepository();
+    fakeAddressesRepository = new FakeAddressesRepository();
 
     listUsers = new ListUsersService(fakeUsersRepository);
   });
 
   it('should be able to list all users', async () => {
-    const user1 = await fakeUsersRepository.create({
+    const user = await fakeUsersRepository.create({
       name: 'John Doe',
       nickname: 'john.doe',
       password: '123456',
@@ -23,7 +26,15 @@ describe('ListUser', () => {
       is_legal: false,
     });
 
-    const user2 = await fakeUsersRepository.create({
+    const allUsers = await listUsers.execute({
+      user_id: user.id,
+    });
+
+    expect(allUsers).not.toEqual([]);
+  });
+
+  it('should be able to list all users by own information', async () => {
+    const user = await fakeUsersRepository.create({
       name: 'John Doe',
       nickname: 'john.doe',
       password: '123456',
@@ -34,8 +45,48 @@ describe('ListUser', () => {
       is_legal: false,
     });
 
-    const allUsers = await listUsers.execute();
+    const allUsers = await listUsers.execute({
+      user_id: user.id,
+      offset: 0,
+      limit: 10,
+      filters: {
+        user: 'John Doe',
+      },
+    });
 
-    expect(allUsers).toEqual([user1, user2]);
+    expect(allUsers).not.toEqual([]);
+  });
+
+  it('should be able to list all users by address information', async () => {
+    const user = await fakeUsersRepository.create({
+      name: 'John Doe',
+      nickname: 'john.doe',
+      password: '123456',
+      email: 'johndoe@example.com',
+      phone: '12988239090',
+      document: '22287634090',
+      cnpj: '',
+      is_legal: false,
+    });
+
+    await fakeAddressesRepository.create({
+      user_id: user.id,
+      zip_code: '12222890',
+      neighborhood: 'Cousain',
+      city: 'Jukuvav',
+      state: 'NJ',
+    });
+
+
+    const allUsers = await listUsers.execute({
+      user_id: user.id,
+      offset: 0,
+      limit: 10,
+      filters: {
+        address: 'Cousain',
+      },
+    });
+
+    expect(allUsers).not.toEqual([]);
   });
 });

--- a/src/modules/users/services/ListUsersService.ts
+++ b/src/modules/users/services/ListUsersService.ts
@@ -4,6 +4,21 @@ import IUsersRepository from '../repositories/IUsersRepository';
 
 import User from '../infra/typeorm/entities/User';
 
+interface IRequest {
+  user_id: string;
+  offset?: number;
+  limit?: number;
+  filters?: {
+    user?: string;
+    address?: string;
+  };
+}
+
+interface IResponse {
+  total: number;
+  results: User[];
+}
+
 @injectable()
 class ListUsersService {
   constructor(
@@ -11,10 +26,31 @@ class ListUsersService {
     private usersRepository: IUsersRepository,
   ) {}
 
-  public async execute(): Promise<User[]> {
-    const users = await this.usersRepository.findAll();
+  public async execute({
+    filters,
+    offset,
+    limit,
+  }: IRequest): Promise<IResponse> {
+    const [
+      users,
+      totalUsers,
+      previous,
+      next,
+    ] = await this.usersRepository.findAll(
+      offset,
+      limit,
+      filters,
+    );
 
-    return users;
+    const responseFormatted = {
+      total: totalUsers,
+      previous,
+      next,
+      results: users,
+    };
+
+    return responseFormatted;
+
   }
 }
 

--- a/src/modules/users/services/ShowUserService.ts
+++ b/src/modules/users/services/ShowUserService.ts
@@ -13,7 +13,7 @@ class ShowUserService {
   ) {}
 
   public async execute(user_id: string): Promise<User> {
-    const user = await this.usersRepository.findById(user_id);
+    const user = await this.usersRepository.showUser(user_id);
 
     if (!user) {
       throw new AppError('User not found', 404);

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -134,11 +134,49 @@
       }
     },
 
-    "/users": {
+    "/users?user=&address=": {
       "get": {
         "tags": ["Users"],
         "summary": "Busca todos os usuários da plataforma",
         "description": "Essa rota permite buscar todos os usuários da plataforma.",
+        "parameters": [
+          {
+            "name": "user",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Parâmetro que permite filtrar pelo nome, e-mail e telefone do usuário."
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Parâmetro que permite filtrar pela cidade e estado do usuário."
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Parâmetro que determina o index pelo qual se deve iniciar a consulta."
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Parâmetro que limita a quantidade de resultados por página."
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success",
@@ -149,12 +187,45 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "email": {
-                        "type": "string"
+                      "total": {
+                        "type": "number"
                       },
-                      "password": {
-                        "type": "string"
-                      }
+                      "previous": {
+                        "type": "boolean"
+                      },
+                      "next": {
+                        "type": "boolean"
+                      },
+                      "results": [
+                        {
+                          "id": {
+                            "type": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "phone": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "number"
+                          },
+                          "address": {
+                            "id": {
+                              "type": "uuid"
+                            },
+                            "city": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -194,11 +265,55 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "id": {
+                        "type": "uuid"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nickname": {
+                        "type": "string"
+                      },
                       "email": {
                         "type": "string"
                       },
-                      "password": {
+                      "phone": {
                         "type": "string"
+                      },
+                      "document": {
+                        "type": "string"
+                      },
+                      "cnpj": {
+                        "type": "string"
+                      },
+                      "is_legal": {
+                        "type": "boolean"
+                      },
+                      "created_at": {
+                        "type": "number"
+                      },
+                      "updated_at": {
+                        "type": "number"
+                      },
+                      "address": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "uuid"
+                          },
+                          "zip_code": {
+                            "type": "string"
+                          },
+                          "neighborhood": {
+                            "type": "string"
+                          },
+                          "city": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
- Ajuste para não retornar campos de documento na listagem de usuários;
- Adição de filtros que permitem buscar por informações do usuário (nome, e-mail e telefone) e endereço (cidade e estado).